### PR TITLE
Added toISOString function and test.

### DIFF
--- a/dateonly.js
+++ b/dateonly.js
@@ -71,6 +71,10 @@
     return this.toDate().toDateString();
   };
 
+  DateOnly.prototype.toISOString = function() {
+    return pad(this.year, 4) + '-' + pad(this.month + 1, 2) + '-' + pad(this.date, 2);
+  }
+
   DateOnly.prototype.toJSON = function() {
     return this.valueOf();
   };

--- a/test/index.js
+++ b/test/index.js
@@ -95,4 +95,10 @@ describe('DateOnly', function() {
     var date = 20120215;
     assert.equal(DateOnly.toDate(date).valueOf(), new Date('03/15/2012').valueOf());
   });
+
+  it('should implement the toISOString function the same as the Date object', function() {
+    var dateOnly = new DateOnly(20180325);
+
+    assert.equal(dateOnly.toISOString(), '2018-04-25');
+  });
 });


### PR DESCRIPTION
JavaScript Date objects has a function toISOString() that I replicated on the DateOnly object. The function returns the DateOnly on ISO format YYYY-MM-DD.
